### PR TITLE
Manual escaping via JavaScript

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
+## 0.0.12
 
+Solved the code escaping problem: https://github.com/kolibril13/plywood-gallery/issues/10
 ## 0.0.11
 
 Python 3.11 support

--- a/plywood_gallery/jinja2_template/template_index.html
+++ b/plywood_gallery/jinja2_template/template_index.html
@@ -412,7 +412,7 @@
 
     // rest the code content block to an empty paragraph 
     function resetContent(imgs) {
-        code_snippet.innerText = "" // Reset the text content
+        code_snippet.innerHTML = "<p> <br> </p>" // Reset the text content
 
         hljs.highlightAll();
     }

--- a/plywood_gallery/jinja2_template/template_index.html
+++ b/plywood_gallery/jinja2_template/template_index.html
@@ -298,7 +298,7 @@
 <code class="python" id="code_snippet"> <br> </code>
 </pre> <!-- better naming of these divs here-->
             <div class='close_button'>
-                <button type="button" onclick="reset_content(this)">X</button>
+                <button type="button" onclick="resetContent(this)">X</button>
             </div>
         </div>
         <div>
@@ -308,7 +308,7 @@
         <div id="gallery_container">
             <template gallery-item-template>
                 <img class='gallery_entry' src='' data-code='' style='width: auto;'
-                    onclick='display_code_from_gallery_cell(this);'>
+                    onclick='displayCode(this);'>
             </template>
 
             <template heading-template>
@@ -400,27 +400,31 @@
 </body>
 
 <script>
+    const codeSnippet = document.getElementById("code_snippet")
+
     hljs.highlightAll();
-    function display_code_from_gallery_cell(imgs) {
-        var name = imgs.dataset.code;
-        document.getElementById("code_snippet").innerHTML = name
-        hljs.highlightAll();
-    }
-    // rest the code content block to an empty paragraph 
-    function reset_content(imgs) {
-        document.getElementById("code_snippet").innerHTML = "<p> <br></p>" //maybe better solution possible?
+    function displayCode(imgs) {
+        // Escape the HTML
+        codeSnippet.innerHTML = new Option(imgs.dataset.code).innerHTML
+        
         hljs.highlightAll();
     }
 
-    let request = new XMLHttpRequest();
+    // rest the code content block to an empty paragraph 
+    function resetContent(imgs) {
+        code_snippet.innerText = "" // Reset the text content
+
+        hljs.highlightAll();
+    }
+
+    const request = new XMLHttpRequest();
     request.open("GET", "{{gallery_parameters_path}}", false);
     request.send(null);
-    let json_content_all = JSON.parse(request.responseText);
-    jsonData = json_content_all["plywood_content"]
+    const jsonData = JSON.parse(request.responseText)["plywood_content"];
 
     const gallery_area = document.getElementById("gallery_container");
 
-    plywood_entries = []
+    const plywoodEntries = []
     for (let key of Object.keys(jsonData)) {
         let chapter_of_html = key
         var template_heading = document.querySelector("[heading-template]");
@@ -442,7 +446,7 @@
             my_img.src = path_of_example;
             my_img.dataset.code = codeblock_of_example;
             gallery_area.appendChild(my_img);
-            plywood_entries.push({ codesnip: codeblock_of_example, img: my_img })
+            plywoodEntries.push({ codesnip: codeblock_of_example, img: my_img })
 
         }
     }
@@ -452,7 +456,7 @@
     searchInput.addEventListener("input", e => {
         const value = e.target.value.toLowerCase()
 
-        plywood_entries.forEach(pw_entry => {
+        plywoodEntries.forEach(pw_entry => {
             const isVisible = pw_entry.codesnip.toLowerCase().includes(value)
             console.log(isVisible)
             if (!isVisible) {

--- a/plywood_gallery/plywood_tools.py
+++ b/plywood_gallery/plywood_tools.py
@@ -89,8 +89,6 @@ class PlywoodGalleryMagic(Magics):
         if new_codeblock:  # checks if there are lines that include "#ONLY" OR "# ONLY"
             code_block = new_codeblock
 
-        # make sure that javascript can read the single quote character
-        code_block = code_block.replace("'", "&#39;")
         code_block = code_block.strip("\n")
 
         # read + update + write json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plywood-gallery"
-version = "0.0.11"
+version = "0.0.12"
 description = "Jupyter cell magic that turns images from cell output into a  gallery"
 authors = ["kolibril13"]
 license = "MIT"


### PR DESCRIPTION
This probably needs better testing. The dev workflow pipeline with the HTML code is a mess outside of vim right now. We might wanna consider to switch to a solution which supports preprocessing like https://kit.svelte.dev does. We also need to run a formatter over that code, since not only tabulation, but also naming of variables greatly differs between places.